### PR TITLE
Links COR destinations are unsafe & Color accessibility

### DIFF
--- a/src/JsonValidate/Pages/Privacy.razor
+++ b/src/JsonValidate/Pages/Privacy.razor
@@ -16,7 +16,7 @@
 <p>
     We do not collect any personal information. However, like most websites we do track cookies for usage 
     analytics via Google Analytics. Click 
-    <a href="https://developers.google.com/analytics/resources/concepts/gaConceptsTrackingOverview" target="_blank">
+    <a href="https://developers.google.com/analytics/resources/concepts/gaConceptsTrackingOverview" target="_blank" rel="noopener">
     here</a> to learn more about the monitoring data that is collected.
 </p>
 
@@ -25,7 +25,7 @@
 <p>
     If you have any queries or complaints about our Privacy Policy please contact us at our 
     <a href="https://github.com/marcusturewicz/JsonValidate.net/issues"
-        aria-label="File any queries or complaints on the GitHub repository" target="_blank">GitHub</a> repository.
+        aria-label="File any queries or complaints on the GitHub repository" target="_blank" rel="noopener">GitHub</a> repository.
 </p>
 
 <h5>Consent</h5>

--- a/src/JsonValidate/Shared/JsonValidator.razor
+++ b/src/JsonValidate/Shared/JsonValidator.razor
@@ -9,9 +9,9 @@
         <textarea @ref="Editor" id="textInput"></textarea>
     </div>
     <div class="form-group">
-        <button class="btn btn-primary" @onclick="Validate">Validate</button>
-        <button class="btn btn-secondary" @onclick="Clear">Clear</button>
-        <button class="btn btn-info" @onclick="Copy">Copy</button>
+        <button class="btn btn-primary" aria-label="Validate JSON" @onclick="Validate">Validate</button>
+        <button class="btn btn-secondary" aria-label="Clear JSON" @onclick="Clear">Clear</button>
+        <button class="btn btn-info" aria-label="Copy JSON" @onclick="Copy">Copy</button>
     </div>    
     @if (IsError)
     {

--- a/src/JsonValidate/Shared/MainLayout.razor
+++ b/src/JsonValidate/Shared/MainLayout.razor
@@ -18,7 +18,7 @@
         <div class="container">
             &copy; @DateTime.Now.Year JSON Validate ·
             <a href="/privacy">Privacy</a> · 
-            <a href="https://github.com/marcusturewicz/jsonvalidate.net/issues" target="_blank">Feedback</a>            
+            <a href="https://github.com/marcusturewicz/jsonvalidate.net/issues" target="_blank" rel="noopener">Feedback</a>            
         </div>
     </footer>    
 </div>

--- a/src/JsonValidate/wwwroot/index.html
+++ b/src/JsonValidate/wwwroot/index.html
@@ -50,11 +50,11 @@
         window.cookieconsent.initialise({
         "palette": {
             "popup": {
-            "background": "#edeff5",
-            "text": "#838391"
+                "background": "#edeff5",
+            "text": "#212529"
             },
             "button": {
-            "background": "#4b81e8"
+            "background": "#1b6ec2"
             }
         },
         "theme": "classic",


### PR DESCRIPTION
**Summary of the changes**

- Added `rel="noopener"` to links that have `target="blank"` associated with them.
- Changed the text of the cookie notice to `#212529`, which seems to be the body color, and the background of the accept to cookie notice to be `#1b6ec2`, which matches the validate button. This passes accessibility validation.

Fixes #77 & #39 (colors for the cookie notice)
